### PR TITLE
Be Very Explicit Where Interaction is Required

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This repository aims to simplify the task by bundling together versions that are
 
 ## Releases
 
+> [!CAUTION]
+> For those who don't read the documentation, here's a summary for you:
+> * Upgrading from [`< v0.1.2`](#v012) requires all cluster to be deleted.
+> * Upgrading from [`< v0.1.3`](#v013) requires image metadata updates.
+> * Upgrading from [`< v0.1.6`](#v016) requires user migration.
+
 ### v0.1.7
 
 _28 January 2025_


### PR DESCRIPTION
People don't read the documentation, and they sure as hell don't read through several versions of release notes, so to prevent people messing up (and me from gloating in a passive aggressive manner), make it really obvious when people need to read the instructions, pinned to the top, in red.